### PR TITLE
Generate subset EPSG Index JSON at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.tgz
+src/_generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geo4326",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1798,7 +1798,8 @@
     "epsg-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/epsg-index/-/epsg-index-1.1.0.tgz",
-      "integrity": "sha512-a74wQNUJdD5MnbTLU7cjRdtxeSL9tEU1ZLztxFtZlHNcIDOqPcNFYp1N7vCe79oBSVK94CYi0LlVTbSTzclkDA=="
+      "integrity": "sha512-a74wQNUJdD5MnbTLU7cjRdtxeSL9tEU1ZLztxFtZlHNcIDOqPcNFYp1N7vCe79oBSVK94CYi0LlVTbSTzclkDA==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "npm run build && npx jest",
     "lint": "npx eslint ./src/",
-    "build": "npx tsc -p ./",
+    "build": "node script/generate.js && npx tsc -p ./",
     "prepublishOnly": "npm run build"
   },
   "author": "yonda <yonda.fountain@gmail.com>",
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@typescript-eslint/parser": "^4.27.0",
+    "epsg-index": "^1.1.0",
     "eslint": "^7.29.0",
     "jest": "^26.6.3",
     "prettier": "2.2.1",
@@ -24,7 +25,6 @@
   "dependencies": {
     "@types/geojson": "^7946.0.7",
     "@types/proj4": "^2.5.0",
-    "epsg-index": "^1.1.0",
     "proj4": "^2.7.0"
   },
   "repository": {

--- a/script/generate.js
+++ b/script/generate.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const epsgIndexAll = require('epsg-index/all.json');
+
+const baseDir = './src/_generated';
+fs.mkdirSync(baseDir, { recursive: true });
+
+const subset = {};
+for (const key in epsgIndexAll) {
+  subset[key] = epsgIndexAll[key].proj4;
+}
+
+let content = `/* eslint-disable */\n\n`;
+
+const license = fs.readFileSync(require.resolve('epsg-index/license.md'), 'utf-8');
+content += `/*\n\nhttps://github.com/derhuerst/epsg-index\n\n${license}\n\n*/\n\n`;
+
+content += `export const epsgIndex = ${JSON.stringify(subset, null, 2)}`;
+
+fs.writeFileSync(path.resolve(baseDir, 'epsg-index.ts'), content);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import epsgIndex from "epsg-index/all.json";
 import type { Position } from "geojson";
 import { Points } from "./types";
 import { validPoint, validLinearRing } from "./_validates";
 import { InvalidCodeError } from "./errors";
 import { EPSILON } from "./constants";
+import { epsgIndex } from "./_generated/epsg-index";
 
 export function _eq(a: number, b: number): boolean {
   return Math.abs(a - b) < EPSILON;
@@ -158,10 +158,10 @@ export function getCrs(code: string | number): string {
       : code;
   if (typeof epsgNumber === "string") return epsgNumber;
 
-  try {
-    const epsgDef = (epsgIndex as any)[epsgNumber]; // eslint-disable-line
-    return epsgDef.proj4; // eslint-disable-line
-  } catch {
+  const epsgDef = (epsgIndex as any)[epsgNumber]; // eslint-disable-line
+  if (epsgDef) {
+    return epsgDef; // eslint-disable-line @typescript-eslint/no-unsafe-return
+  } else {
     throw new InvalidCodeError();
   }
 }


### PR DESCRIPTION
- epsg-index/all.json is very heavy (about 6MB) and performance deteriorates when used in a browser.
- The actual size of only the fields used was found to be about 1/10 of the total.
- In this PR, a compressed JSON file is generated at build time.
